### PR TITLE
ci: remove sleep

### DIFF
--- a/.github/workflows/codacy-baseline-fixer.yml
+++ b/.github/workflows/codacy-baseline-fixer.yml
@@ -27,7 +27,7 @@ jobs:
           echo "Analizando PR #$PR_NUMBER..."
           
           # 2. Wait for report
-          sleep 60 
+          #sleep 60 
 
           # 3. Check validation
           ALL_CHECKS=$(gh pr checks "$PR_NUMBER" --repo "${{ github.repository }}")


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Comment out the sleep command in the Codacy baseline fixer workflow to avoid unnecessary waiting before checking PR validation.