### PR TITLE
ci: update build-report.yml

### DIFF
--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -11,7 +11,8 @@ on:
   pull_request:
     branches:
       - '**'
-
+  schedule:
+    - cron: '0 3 * * *' # Every day at 03:00 UTC
 jobs:
 
   verify:


### PR DESCRIPTION
Add scheduled job to run daily at 03:00 UTC.

## Summary by Sourcery

CI:
- Schedule the build report workflow to run daily at 03:00 UTC.